### PR TITLE
feat: able to define a custom mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,16 @@ Or as a global package:
 $ npm i -g sync-pom-version
 $ sync-pom-version <path-to-pom> <path-to-package-json>
 ```
+## Options
+
+```
+$ sync-pom-version --help
+
+  Usage: sync-pom-version [pom.xml] [package.json]
+
+  Options:
+
+    -s, --source [source]  the regular expression used to parse the POM version (default: (\d+).(\d+).(\d+).*)
+    -t, --target [target]  the replacement used to set the package.json version (default: $1.$2.$3)
+    -h, --help             output usage information
+```

--- a/index.js
+++ b/index.js
@@ -1,11 +1,20 @@
-
+var program = require('commander');
 var fs = require('fs');
 var parse = require('xml-parser');
 
-var args = process.argv.splice(2);
-var pomPath = args.length ? args[0] : 'pom.xml';
-var packagePath = args.length >= 2 ? args[1] : 'package.json';
+var defaultPom = "pom.xml";
+var defaultPackage = "package.json";
+var defaultRegex = "(\\d+).(\\d+).(\\d+).*";
+var defaultReplacement = "$1.$2.$3";
 
+program
+    .usage('[' + defaultPom + '] [' + defaultPackage + ']')
+    .option('-s, --source [source]', 'the regular expression used to parse the POM version', defaultRegex)
+    .option('-t, --target [target]', 'the replacement used to set the package.json version', defaultReplacement)
+    .parse(process.argv);
+
+var pomPath = program.args[0] || defaultPom;
+var packagePath = program.args[1] || defaultPackage;
 main(pomPath, packagePath);
 
 function main (pomPath, packagePath) {
@@ -17,23 +26,24 @@ function main (pomPath, packagePath) {
       pomVersionNode = extractPomVersionNode(parent);
   }
 
-  var pomVersion = pomVersionNode.content.replace(/[\.-](RELEASE|FINAL)$/i, '');
-
+  var pomVersion = pomVersionNode.content;
   console.log('found version ' + pomVersion + ' in pom.xml');
 
   var packageContent = fs.readFileSync(packagePath, 'utf8');
   var packageVersion = JSON.parse(packageContent).version;
-
   console.log('found version ' + packageVersion + ' in package.json');
 
-  if (pomVersion === packageVersion) {
+  var pomRegex = program.source || defaultRegex;
+  var packageReplacement = program.target || defaultReplacement;
+  var newPackageVersion = pomVersion.replace(new RegExp(pomRegex), packageReplacement);
+
+  if (packageVersion === newPackageVersion) {
     return;
   }
 
-  var newPackageContent = packageContent.replace(formatVersion(packageVersion), formatVersion(pomVersion));
+  var newPackageContent = packageContent.replace(formatVersion(packageVersion), formatVersion(newPackageVersion));
   fs.writeFileSync(packagePath, newPackageContent, 'utf8');
-
-  console.log('package.json updated to version ' + pomVersion);
+  console.log('package.json updated to version ' + newPackageVersion);
 }
 
 function extractParentNode(node) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,34 @@
+{
+  "name": "sync-pom-version",
+  "version": "1.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "commander": {
+      "version": "2.17.1",
+      "resolved": "http://mvn.intranet/nexus/repository/npm-public/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "http://mvn.intranet/nexus/repository/npm-public/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "http://mvn.intranet/nexus/repository/npm-public/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "xml-parser": {
+      "version": "1.2.1",
+      "resolved": "http://mvn.intranet/nexus/repository/npm-public/xml-parser/-/xml-parser-1.2.1.tgz",
+      "integrity": "sha1-wx9MNPKXXbgq0BMiISBZJzYVb80=",
+      "requires": {
+        "debug": "^2.2.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "sync-pom-version": "bin/sync"
   },
   "dependencies": {
+    "commander": "^2.17.1",
     "xml-parser": "~1.2.1"
   },
   "repository": {


### PR DESCRIPTION
Examples:

given the pom version 1.0.4.9-SNAPSHOT
you want transform it in 1.0.4-sr9
so set the following options:
--source='(\d+).(\d+).(\d+).(\d+).*'
--target='$1.$2.$3-sr$4'